### PR TITLE
fix class HexCodec is not found

### DIFF
--- a/tracecontext/pom.xml
+++ b/tracecontext/pom.xml
@@ -90,6 +90,7 @@
                   <includes>
                     <include>brave/internal/extra/*.class</include>
                     <include>brave/internal/codec/EntrySplitter*.class</include>
+                    <include>brave/internal/codec/HexCodec*.class</include>
                     <include>brave/internal/collect/Lists*.class</include>
                     <include>brave/internal/collect/LongBitSet*.class</include>
                     <include>brave/internal/collect/UnsafeArrayMap*.class</include>


### PR DESCRIPTION
HexCodec is being used and the pom file is not including it. Hence, the change. 