### PR TITLE
Overhauls TraceContextExtractor

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,41 @@
 [![Gitter chat](http://img.shields.io/badge/gitter-join%20chat%20%E2%86%92-brightgreen.svg)](https://gitter.im/openzipkin/zipkin)
 [![Build Status](https://github.com/openzipkin-contrib/brave-propagation-w3c/workflows/test/badge.svg)](https://github.com/openzipkin-contrib/brave-propagation-w3c/actions?query=workflow%3Atest)
 
-This is a work-in-progress originally imported from openzipkin/brave#693
+This is not usable, yet, as it doesn't fall-back to B3 on failure. Also, both specs and
+implementations are unclear about use of "tracestate".
 
-This is not usable, yet, because it is unclear about use of "tracestate". While this is something
-others punt, it isn't acceptable here. Once things are clear and clean, we'll say it is usable.
+## Why tracestate is mostly unusable
+
+It is questionable the value of this except treating `traceparent` the same as `b3` considering what
+has happened in the tracing ecosystem. The primary custodians of w3c trace-context are also the
+primary custodians of OpenTelemetry.
+
+OpenTelemetry switched the primary trace format from `b3` to `traceparent` + `tracestate`. However,
+they did so without fully implementing the specification, notably only implementing the `tracestate`
+format, but not the processing model of it.
+
+This causes an unresolvable conflict when anyone uses `tracestate` processing model in the same
+system with a broken implementation (ex OpenTelemetry). Concretely, OpenTelemetry blindly copies the
+`tracestate` while *also* mutating `traceparent`. It has no implementation to participate in the
+processing model a library like this would implement.
+
+The impact is that a receiver that implements `tracestate` processing cannot know how to prioritize
+in this circumstance without manual coordination. For example, it could know from special deployment
+knowledge that upstream is OpenTelemetry and invert the usual priority of `tracestate` over
+`traceparent`. Without any special knowledge, following processing norms would actually break traces
+as a stale upstream parent would be used as it wouldn't expect `traceparent` mutated + sending to
+the same system unless that processor also mutating the corresponding entry in `tracestate`.
+
+Hence, it is questionable if there's any sense at all using `tracestate`. Besides manual
+coordination, it could be helpful to comform to the broken practice of treating `traceparent` the
+same as the `b3` header and `tracestate` as arbitrary baggage. In other words, we would forward it,
+but never use it. In doing so, it becomes an inefficient implementation of `b3` losing the only
+technical merit of `tracestate`, which is durability of the position in a trace.
 
 ## Trace Context format
 See [here](tracecontext/README.md) for instructions on how to use the [Trace Context](https://w3c.github.io/trace-context/) format.
+
+https://github.com/w3c/trace-state-ids-registry/issues/2
 
 ## Artifacts
 All artifacts publish to the group ID "io.zipkin.contrib.brave-propagation-w3c". We use a common

--- a/README.md
+++ b/README.md
@@ -29,10 +29,11 @@ as a stale upstream parent would be used as it wouldn't expect `traceparent` mut
 the same system unless that processor also mutating the corresponding entry in `tracestate`.
 
 Hence, it is questionable if there's any sense at all using `tracestate`. Besides manual
-coordination, it could be helpful to comform to the broken practice of treating `traceparent` the
-same as the `b3` header and `tracestate` as arbitrary baggage. In other words, we would forward it,
-but never use it. In doing so, it becomes an inefficient implementation of `b3` losing the only
-technical merit of `tracestate`, which is durability of the position in a trace.
+coordination, another way to progress is to conform to the broken practice of treating `traceparent`
+the same as the `b3` header and `tracestate` as arbitrary baggage. In other words, we would not
+implement the processing model or look for entries. We would forward `tracestate`, but never use it.
+That option is an inefficient implementation of `b3`, losing the main merit of `tracestate`:
+durability of a reliable last position in a trace.
 
 ## Trace Context format
 See [here](tracecontext/README.md) for instructions on how to use the [Trace Context](https://w3c.github.io/trace-context/) format.

--- a/benchmarks/src/main/java/brave/propagation/tracecontext/TraceContextPropagationBenchmarks.java
+++ b/benchmarks/src/main/java/brave/propagation/tracecontext/TraceContextPropagationBenchmarks.java
@@ -41,7 +41,7 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 @BenchmarkMode(Mode.SampleTime)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
 public class TraceContextPropagationBenchmarks {
-  static final Propagation<String> tc = TraceContextPropagation.create().get();
+  static final Propagation<String> tc = TraceContextPropagation.get();
   static final Injector<Map<String, String>> tcInjector = tc.injector(Map::put);
   static final Extractor<Map<String, String>> tcExtractor = tc.extractor(Map::get);
 
@@ -55,14 +55,13 @@ public class TraceContextPropagationBenchmarks {
   // TODO: add tracestate examples which prefer the b3 entry
   static final Map<String, String> incoming = new LinkedHashMap<String, String>() {
     {
-      put("traceparent", TraceparentFormat.writeTraceparentFormat(context));
+      put("traceparent", TraceparentFormat.get().write(context));
     }
   };
 
   static final Map<String, String> incomingPadded = new LinkedHashMap<String, String>() {
     {
-      put("traceparent",
-        TraceparentFormat.writeTraceparentFormat(context.toBuilder().traceIdHigh(0).build()));
+      put("traceparent", TraceparentFormat.get().write(context.toBuilder().traceIdHigh(0).build()));
     }
   };
 

--- a/tracecontext/pom.xml
+++ b/tracecontext/pom.xml
@@ -84,7 +84,6 @@
                 <filter>
                   <artifact>${brave.groupId}:brave</artifact>
                   <includes>
-                    <include>brave/internal/extra/*.class</include>
                     <include>brave/internal/codec/EntrySplitter*.class</include>
                     <include>brave/internal/codec/HexCodec*.class</include>
                     <include>brave/internal/collect/Lists*.class</include>

--- a/tracecontext/src/main/java/brave/propagation/tracecontext/TraceContextExtractor.java
+++ b/tracecontext/src/main/java/brave/propagation/tracecontext/TraceContextExtractor.java
@@ -17,51 +17,89 @@ import brave.propagation.Propagation.Getter;
 import brave.propagation.TraceContext;
 import brave.propagation.TraceContext.Extractor;
 import brave.propagation.TraceContextOrSamplingFlags;
+import java.util.Arrays;
 
 import static brave.propagation.B3SingleFormat.parseB3SingleFormat;
 import static brave.propagation.tracecontext.TraceContextPropagation.TRACEPARENT;
 import static brave.propagation.tracecontext.TraceContextPropagation.TRACESTATE;
+import static brave.propagation.tracecontext.internal.CharSequences.withoutSubSequence;
 
-// TODO: this class has no useful tests wrt traceparent yet
 final class TraceContextExtractor<R> implements Extractor<R> {
   final Getter<R, String> getter;
-  final TraceContextPropagation propagation;
+  final TraceparentFormat traceparentFormat;
+  final TracestateFormat tracestateFormat;
+  final String tracestateKey;
 
   TraceContextExtractor(TraceContextPropagation propagation, Getter<R, String> getter) {
     this.getter = getter;
-    this.propagation = propagation;
+    this.traceparentFormat = propagation.traceparentFormat;
+    this.tracestateFormat = propagation.tracestateFormat;
+    this.tracestateKey = propagation.tracestateKey;
   }
 
   @Override public TraceContextOrSamplingFlags extract(R request) {
     if (request == null) throw new NullPointerException("request == null");
+
+    // Below implies both headers must be present or all is invalid
+    //
+    // MUST propagate the traceparent and tracestate headers
+    // https://www.w3.org/TR/trace-context/#design-overview
+    // If a tracestate header is received without an accompanying traceparent header, it is invalid and MUST be discarded.
+    // https://www.w3.org/TR/trace-context/#no-traceparent-received
     String traceparentString = getter.get(request, TRACEPARENT);
     if (traceparentString == null) return TraceContextOrSamplingFlags.EMPTY;
-
-    // TODO: add link that says tracestate itself is optional
     String tracestateString = getter.get(request, TRACESTATE);
-    if (tracestateString == null) {
-      // NOTE: we may not want to pay attention to the sampled flag. Since it conflates
-      // not-yet-sampled with sampled=false, implementations that always set flags to -00 would
-      // never be traced!
-      //
-      // NOTE: We are required to use the same trace ID, there's some vagueness about the parent
-      // span ID. Ex we don't know if upstream are sending to the same system or not, when we can't
-      // read the tracestate header. Trusting the span ID (traceparent calls the span ID parent-id)
-      // could result in a headless trace.
-      TraceContext maybeUpstream = TraceparentFormat.parseTraceparentFormat(traceparentString);
-      return TraceContextOrSamplingFlags.create(maybeUpstream);
+    if (tracestateString == null) return TraceContextOrSamplingFlags.EMPTY;
+
+    // Below implies traceparent must be valid or all is invalid.
+    //
+    // If the vendor failed to parse traceparent, it MUST NOT attempt to parse tracestate.
+    // Note that the opposite is not true: failure to parse tracestate MUST NOT affect the parsing of traceparent.
+    // https://www.w3.org/TR/trace-context/#tracestate-header
+    TraceContext maybeUpstream = traceparentFormat.parse(traceparentString);
+    if (maybeUpstream == null) return TraceContextOrSamplingFlags.EMPTY;
+
+    // The spec is vague about tracestate handling. We are allowed to parse, ignore or toss it.
+    // This implementation chooses to toss a malformed tracestate header.
+    //
+    // The vendor MAY validate the tracestate header.
+    // If the tracestate header cannot be parsed the vendor MAY discard the entire header.
+    // Invalid tracestate entries MAY also be discarded.
+    // https://www.w3.org/TR/trace-context/#a-traceparent-is-received
+    // failure to parse tracestate MUST NOT affect the parsing of traceparent.
+    // https://www.w3.org/TR/trace-context/#tracestate-header
+    int[] indices = new int[6];
+    Arrays.fill(indices, -1);
+    if (!tracestateFormat.parseInto(tracestateString, indices)) {
+      return TraceContextOrSamplingFlags.EMPTY; // malformed per tracestate spec
     }
 
-    Tracestate tracestate = propagation.tracestateFactory.create();
-    TraceContextOrSamplingFlags extracted = null;
-    if (TracestateFormat.INSTANCE.parseInto(tracestateString, tracestate)) {
-      String b3 = tracestate.get(propagation.tracestateKey);
-      if (b3 != null) {
-        tracestate.put(propagation.tracestateKey, null);
-        extracted = parseB3SingleFormat(b3);
-      }
+    // At this point, we know that traceparent and tracestate are valid. We need to choose what, if
+    // anything to read. The priority is tracestate for the primary trace context, if it includes
+    // our entry. Otherwise, we will try the same trace ID from traceparent.
+
+    // First check if our entry is inside tracestate. If so, we ignore traceparent when well-formed.
+    if (indices[1] != -1) {
+      TraceContextOrSamplingFlags fromB3Entry =
+        parseB3SingleFormat(tracestateString, indices[3], indices[4]);
+      if (fromB3Entry == null) return TraceContextOrSamplingFlags.EMPTY; // malformed per B3 spec
+      Tracestate tracestate = Tracestate.create(withoutB3(tracestateString, indices));
+      return fromB3Entry.toBuilder().addExtra(tracestate).build();
     }
-    if (extracted == null) extracted = TraceContextOrSamplingFlags.EMPTY;
-    return extracted.toBuilder().addExtra(tracestate).build();
+
+    // Finally, we have a valid traceparent and a possibly empty tracestate lacking our entry.
+    // We trust the traceparent as a part of our system and carry forward tracestate we received.
+    return TraceContextOrSamplingFlags.newBuilder(maybeUpstream)
+      .addExtra(Tracestate.create(tracestateString))
+      .build();
+  }
+
+  static CharSequence withoutB3(String tracestateString, int[] indices) {
+    if (indices[0] == -1 && indices[5] == -1) return "";
+
+    int firstIndexToSkip = indices[0] != -1 ? tracestateString.indexOf(',', indices[0]) : 0;
+    if (indices[4] != tracestateString.length() && firstIndexToSkip != 0) firstIndexToSkip++;
+    return withoutSubSequence(tracestateString, firstIndexToSkip,
+      indices[5] != -1 ? indices[5] : indices[4]);
   }
 }

--- a/tracecontext/src/main/java/brave/propagation/tracecontext/internal/CharSequences.java
+++ b/tracecontext/src/main/java/brave/propagation/tracecontext/internal/CharSequences.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.propagation.tracecontext.internal;
+
+// temporary copy of brave.internal.Charsequences until next Brave release, where we can shade it.
+public final class CharSequences {
+  /**
+   * Returns true if the input range contains only the expected characters.
+   *
+   * @param expected   characters to search for in the input
+   * @param input      charSequence to search for {@code expected}
+   * @param beginIndex begin index of the {@code input}, inclusive
+   * @param endIndex   end index of the {@code input}, exclusive
+   * @return true if we reached the {@code endIndex} without failures.
+   * @see String#regionMatches(int, String, int, int) similar, except for {@link String}
+   */
+  public static boolean regionMatches(
+    CharSequence expected, CharSequence input, int beginIndex, int endIndex) {
+    if (expected == null) throw new NullPointerException("expected == null");
+    if (input == null) throw new NullPointerException("input == null");
+    int regionLength = regionLength(input.length(), beginIndex, endIndex);
+    if (expected.length() > regionLength) return false;
+    for (int i = 0, inputIndex = beginIndex; i < regionLength; i++, inputIndex++) {
+      if (expected.charAt(i) != input.charAt(inputIndex)) return false;
+    }
+    return true;
+  }
+
+  /** Opposite of {@link CharSequence#subSequence(int, int)} */
+  public static CharSequence withoutSubSequence(CharSequence input, int beginIndex, int endIndex) {
+    if (input == null) throw new NullPointerException("input == null");
+    int length = input.length();
+
+    // Exit early if the region is empty or the entire input
+    int skippedRegionLength = regionLength(length, beginIndex, endIndex);
+    if (skippedRegionLength == 0) return input;
+    if (beginIndex == 0 && endIndex == length) return "";
+
+    // Exit early if the region ends on a boundary.
+    // This doesn't use input.subsequence as it might allocate a String
+    if (beginIndex == 0) return new SubSequence(input, endIndex, length);
+    if (endIndex == length) return new SubSequence(input, 0, beginIndex);
+
+    // Otherwise, the region to skip in the middle
+    return new WithoutSubSequence(input, 0, beginIndex, endIndex, length);
+  }
+
+  static int regionLength(int inputLength, int beginIndex, int endIndex) {
+    if (beginIndex < 0) throw new IndexOutOfBoundsException("beginIndex < 0");
+    if (endIndex < 0) throw new IndexOutOfBoundsException("endIndex < 0");
+    if (beginIndex > endIndex) throw new IndexOutOfBoundsException("beginIndex > endIndex");
+    int regionLength = endIndex - beginIndex;
+    if (endIndex > inputLength) throw new IndexOutOfBoundsException("endIndex > input");
+    return regionLength;
+  }
+
+  /** Avoids implicit string allocation when the input calls {@link String#subSequence(int, int)} */
+  static final class SubSequence implements CharSequence {
+    final CharSequence input;
+    final int begin, end, length;
+
+    SubSequence(CharSequence input, int begin, int end) {
+      this.input = input;
+      this.begin = begin;
+      this.end = end;
+      this.length = end - begin;
+    }
+
+    @Override public int length() {
+      return length;
+    }
+
+    @Override public char charAt(int index) {
+      if (index < 0) throw new IndexOutOfBoundsException("index < 0");
+      if (index >= length) throw new IndexOutOfBoundsException("index >= length");
+      return input.charAt(begin + index);
+    }
+
+    @Override public CharSequence subSequence(int beginIndex, int endIndex) {
+      int newLength = regionLength(length, beginIndex, endIndex);
+      if (newLength == 0) return "";
+      if (newLength == length) return this;
+      return new SubSequence(input, beginIndex + begin, endIndex + begin);
+    }
+
+    @Override public String toString() {
+      return new StringBuilder(length).append(input, begin, end).toString();
+    }
+  }
+
+  static final class WithoutSubSequence implements CharSequence {
+    final CharSequence input;
+    final int begin, beginSkip, endSkip, end, skipLength, length;
+
+    WithoutSubSequence(
+      CharSequence input, int begin, int beginSkip, int endSkip, int end) {
+      this.input = input;
+      this.begin = begin;
+      this.beginSkip = beginSkip;
+      this.endSkip = endSkip;
+      this.end = end;
+      this.skipLength = endSkip - beginSkip;
+      this.length = end - begin - skipLength;
+    }
+
+    @Override public int length() {
+      return length;
+    }
+
+    @Override public char charAt(int index) {
+      if (index < 0) throw new IndexOutOfBoundsException("index < 0");
+      if (index >= length) throw new IndexOutOfBoundsException("index >= length");
+      index += begin;
+      if (index >= beginSkip) index += skipLength;
+      return input.charAt(index);
+    }
+
+    @Override public CharSequence subSequence(int beginIndex, int endIndex) {
+      int newLength = regionLength(length, beginIndex, endIndex);
+      if (newLength == 0) return "";
+      if (newLength == length) return this;
+
+      // Move the input positions to the relative offset
+      beginIndex += begin;
+      endIndex += begin;
+
+      // Check to see if we are before the skipped region
+      if (endIndex <= beginSkip) return new SubSequence(input, beginIndex, endIndex);
+
+      // We now know we either include the skipped region or start after it
+      endIndex += skipLength;
+
+      // If we are after the skipped region, return a subsequence
+      if (beginIndex >= beginSkip) return new SubSequence(input, beginIndex + skipLength, endIndex);
+
+      // We happened to require both sides of the skipped region, so narrow it according to inputs.
+      return new WithoutSubSequence(input, beginIndex, beginSkip, endSkip, endIndex);
+    }
+
+    @Override public String toString() {
+      // Careful here to use .append(input, begin, end), not .append(input.subsequence(begin, end))
+      // The latter can allocate temporary strings, subverting the purpose of using StringBuilder!
+      return new StringBuilder(length)
+        .append(input, begin, beginSkip)
+        .append(input, endSkip, end).toString();
+    }
+  }
+}

--- a/tracecontext/src/test/java/brave/propagation/tracecontext/BasicUsageTest.java
+++ b/tracecontext/src/test/java/brave/propagation/tracecontext/BasicUsageTest.java
@@ -31,7 +31,7 @@ class BasicUsageTest {
 
   @Test void basicUsage() {
     try (Tracing tracing = Tracing.newBuilder()
-      .propagationFactory(TraceContextPropagation.create())
+      .propagationFactory(TraceContextPropagation.FACTORY)
       .addSpanHandler(spans)
       .build()) {
 
@@ -54,7 +54,7 @@ class BasicUsageTest {
 
         Span server = serverHandler.handleReceive(new FakeHttpRequest.Server(request));
         assertThat(server.context().parentIdString())
-          .isEqualTo(client.context().spanIdString()); // trace continued
+          .isEqualTo(client.context().parentIdString()); // trace continued
 
         server.finish();
         client.finish();

--- a/tracecontext/src/test/java/brave/propagation/tracecontext/TraceContextPropagationClassLoaderTest.java
+++ b/tracecontext/src/test/java/brave/propagation/tracecontext/TraceContextPropagationClassLoaderTest.java
@@ -30,19 +30,18 @@ class TraceContextPropagationClassLoaderTest {
 
   static class BasicUsage implements Runnable {
     @Override public void run() {
-      Propagation.Factory propagation = TraceContextPropagation.create();
-      Injector<Map<String, String>> injector = propagation.get().injector(Map::put);
-      Extractor<Map<String, String>> extractor = propagation.get().extractor(Map::get);
+      Propagation<String> propagation = TraceContextPropagation.get();
+      Injector<Map<String, String>> injector = propagation.injector(Map::put);
+      Extractor<Map<String, String>> extractor = propagation.extractor(Map::get);
 
-      TraceContext context =
-        propagation.decorate(TraceContext.newBuilder().traceId(1L).spanId(2L).build());
+      TraceContext context = TraceContext.newBuilder().traceId(1L).spanId(2L).build();
 
       Map<String, String> headers = new LinkedHashMap<>();
       injector.inject(context, headers);
 
       String traceparent = headers.get("traceparent");
       if (!"00-00000000000000000000000000000001-0000000000000002-00".equals(traceparent)) {
-        throw new AssertionError();
+        throw new AssertionError(traceparent);
       }
 
       if (!context.equals(extractor.extract(headers).context())) {

--- a/tracecontext/src/test/java/brave/propagation/tracecontext/TraceContextPropagationTest.java
+++ b/tracecontext/src/test/java/brave/propagation/tracecontext/TraceContextPropagationTest.java
@@ -13,21 +13,36 @@
  */
 package brave.propagation.tracecontext;
 
+import brave.internal.Nullable;
 import brave.propagation.Propagation;
 import brave.propagation.TraceContext;
 import brave.propagation.TraceContext.Extractor;
 import brave.propagation.TraceContext.Injector;
-import brave.propagation.TraceContextOrSamplingFlags;
+import brave.propagation.tracecontext.TraceContextPropagation.LoggerHolder;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import static brave.internal.codec.HexCodec.lowerHexToUnsignedLong;
+import static brave.propagation.tracecontext.TraceContextPropagation.logOrThrow;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
+@ExtendWith(MockitoExtension.class)
 class TraceContextPropagationTest {
   Map<String, String> request = new LinkedHashMap<>();
-  Propagation.Factory propagation = TraceContextPropagation.create();
+  Propagation.Factory propagation = TraceContextPropagation.newFactoryBuilder().build();
   Injector<Map<String, String>> injector = propagation.get().injector(Map::put);
   Extractor<Map<String, String>> extractor = propagation.get().extractor(Map::get);
 
@@ -41,40 +56,53 @@ class TraceContextPropagationTest {
   String validB3Single = "67891233abcdef012345678912345678-463ac35c9f6413ad-1";
   String otherState = "congo=t61rcWkgMzE";
 
-  @Test void injects_b3_when_no_other_tracestate() {
-    sampledContext = propagation.decorate(sampledContext);
+  @Mock Logger logger;
 
+  @Test void injects_b3_when_no_other_tracestate() {
     injector.inject(sampledContext, request);
 
-    assertThat(request).containsEntry("tracestate", "b3=" + validB3Single);
+    assertThat(request)
+      .containsEntry("traceparent", validTraceparent)
+      .containsEntry("tracestate", "b3=" + validB3Single);
   }
 
   @Test void injects_b3_before_other_tracestate() {
-    sampledContext = propagation.decorate(sampledContext);
-    TracestateFormat.INSTANCE.parseInto(otherState, sampledContext.findExtra(Tracestate.class));
+    TraceContext withTracestate =
+      sampledContext.toBuilder().addExtra(new Tracestate(otherState)).build();
 
-    injector.inject(sampledContext, request);
+    injector.inject(withTracestate, request);
 
-    assertThat(request).containsEntry("tracestate", "b3=" + validB3Single + "," + otherState);
+    assertThat(request)
+      .containsEntry("traceparent", validTraceparent)
+      .containsEntry("tracestate", "b3=" + validB3Single + "," + otherState);
   }
 
   @Test void extracts_b3_when_no_other_tracestate() {
     request.put("traceparent", validTraceparent);
     request.put("tracestate", "b3=" + validB3Single);
 
-    assertThat(extractor.extract(request)).isEqualTo(
-      TraceContextOrSamplingFlags.create(propagation.decorate(sampledContext)));
+    assertExtracted(extractor.extract(request).context(), null);
   }
 
   @Test void extracts_b3_before_other_tracestate() {
     request.put("traceparent", validTraceparent);
     request.put("tracestate", "b3=" + validB3Single + "," + otherState);
 
-    sampledContext = propagation.decorate(sampledContext);
-    TracestateFormat.INSTANCE.parseInto(otherState, sampledContext.findExtra(Tracestate.class));
+    assertExtracted(extractor.extract(request).context(), otherState);
+  }
 
-    assertThat(extractor.extract(request))
-      .isEqualTo(TraceContextOrSamplingFlags.create(sampledContext));
+  @Test void extracts_b3_after_other_tracestate() {
+    request.put("traceparent", validTraceparent);
+    request.put("tracestate", otherState + ",b3=" + validB3Single);
+
+    assertExtracted(extractor.extract(request).context(), otherState);
+  }
+
+  @Test void extracts_b3_between_other_tracestate_withSpaces() {
+    request.put("traceparent", validTraceparent);
+    request.put("tracestate", "app_id=1, b3=" + validB3Single + ", " + otherState);
+
+    assertExtracted(extractor.extract(request).context(), "app_id=1," + otherState);
   }
 
   @Test void extracted_toString() {
@@ -89,14 +117,69 @@ class TraceContextPropagationTest {
         + "}");
   }
 
-  @Test void extracts_b3_after_other_tracestate() {
-    request.put("traceparent", validTraceparent);
-    request.put("tracestate", otherState + ",b3=" + validB3Single);
+  @Test void logOrThrow_logs() {
+    when(logger.isLoggable(Level.FINE)).thenReturn(true);
 
-    sampledContext = propagation.decorate(sampledContext);
-    TracestateFormat.INSTANCE.parseInto(otherState, sampledContext.findExtra(Tracestate.class));
+    try (MockedStatic<LoggerHolder> mb = mockStatic(LoggerHolder.class)) {
+      mb.when(LoggerHolder::logger).thenReturn(logger);
 
-    assertThat(extractor.extract(request))
-      .isEqualTo(TraceContextOrSamplingFlags.create(sampledContext));
+      assertThat(logOrThrow("hello", false))
+        .isFalse(); // instead of raising exception
+    }
+
+    verify(logger).log(Level.FINE, "hello");
+  }
+
+  @Test void logOrThrow_skips_log() {
+    when(logger.isLoggable(Level.FINE)).thenReturn(false);
+
+    try (MockedStatic<LoggerHolder> mb = mockStatic(LoggerHolder.class)) {
+      mb.when(LoggerHolder::logger).thenReturn(logger);
+
+      assertThat(logOrThrow("hello", false))
+        .isFalse(); // instead of raising exception
+    }
+
+    verify(logger).isLoggable(Level.FINE);
+    verifyNoMoreInteractions(logger);
+  }
+
+  @Test void logOrThrow_logs_param() {
+    when(logger.isLoggable(Level.FINE)).thenReturn(true);
+
+    try (MockedStatic<LoggerHolder> mb = mockStatic(LoggerHolder.class)) {
+      mb.when(LoggerHolder::logger).thenReturn(logger);
+
+      assertThat(logOrThrow("hello {0}", "world", false))
+        .isFalse(); // instead of raising exception
+    }
+
+    verify(logger).log(any(LogRecord.class));
+  }
+
+  @Test void logOrThrow_skips_log_param() {
+    when(logger.isLoggable(Level.FINE)).thenReturn(false);
+
+    try (MockedStatic<LoggerHolder> mb = mockStatic(LoggerHolder.class)) {
+      mb.when(LoggerHolder::logger).thenReturn(logger);
+
+      assertThat(logOrThrow("hello {0}", "world", false))
+        .isFalse(); // instead of raising exception
+    }
+
+    verify(logger).isLoggable(Level.FINE);
+    verifyNoMoreInteractions(logger);
+  }
+
+  void assertExtracted(TraceContext extracted, @Nullable String otherState) {
+    assertThat(extracted)
+      .usingRecursiveComparison().ignoringFields("extraList")
+      .isEqualTo(sampledContext);
+    if (otherState == null) {
+      assertThat(extracted.findExtra(Tracestate.class).otherState).isNull();
+    } else {
+      assertThat(extracted.findExtra(Tracestate.class).otherState)
+        .hasToString(otherState);
+    }
   }
 }

--- a/tracecontext/src/test/java/brave/propagation/tracecontext/TraceparentFormatTest.java
+++ b/tracecontext/src/test/java/brave/propagation/tracecontext/TraceparentFormatTest.java
@@ -13,94 +13,84 @@
  */
 package brave.propagation.tracecontext;
 
-import brave.internal.Platform;
 import brave.propagation.TraceContext;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.MockedStatic;
-import org.mockito.junit.jupiter.MockitoExtension;
 
-import static brave.propagation.tracecontext.TraceparentFormat.parseTraceparentFormat;
-import static brave.propagation.tracecontext.TraceparentFormat.writeTraceparentFormat;
-import static brave.propagation.tracecontext.TraceparentFormat.writeTraceparentFormatAsBytes;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mockStatic;
-import static org.mockito.Mockito.verify;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-@ExtendWith(MockitoExtension.class)
 class TraceparentFormatTest {
   String traceIdHigh = "1234567890123459";
   String traceId = "1234567890123451";
   String parentId = "1234567890123452";
   String spanId = "1234567890123453";
 
-  @Mock Platform platform;
+  TraceparentFormat traceparentFormat = new TraceparentFormat(true);
 
   /** unsampled isn't the same as not-yet-sampled, but we have no better choice */
-  @Test void writeTraceparentFormat_notYetSampled_128() {
+  @Test void write_notYetSampled_128() {
     TraceContext context = TraceContext.newBuilder()
       .traceIdHigh(Long.parseUnsignedLong(traceIdHigh, 16))
       .traceId(Long.parseUnsignedLong(traceId, 16))
       .spanId(Long.parseUnsignedLong(spanId, 16)).build();
 
-    assertThat(writeTraceparentFormat(context))
+    assertThat(traceparentFormat.write(context))
       .isEqualTo("00-" + traceIdHigh + traceId + "-" + spanId + "-00")
-      .isEqualTo(new String(writeTraceparentFormatAsBytes(context), UTF_8));
+      .isEqualTo(new String(traceparentFormat.writeAsBytes(context), UTF_8));
   }
 
-  @Test void writeTraceparentFormat_unsampled() {
+  @Test void write_unsampled() {
     TraceContext context = TraceContext.newBuilder()
       .traceId(Long.parseUnsignedLong(traceId, 16))
       .spanId(Long.parseUnsignedLong(spanId, 16))
       .sampled(false).build();
 
-    assertThat(writeTraceparentFormat(context))
+    assertThat(traceparentFormat.write(context))
       .isEqualTo("00-0000000000000000" + traceId + "-" + spanId + "-00")
-      .isEqualTo(new String(writeTraceparentFormatAsBytes(context), UTF_8));
+      .isEqualTo(new String(traceparentFormat.writeAsBytes(context), UTF_8));
   }
 
-  @Test void writeTraceparentFormat_sampled() {
+  @Test void write_sampled() {
     TraceContext context = TraceContext.newBuilder()
       .traceId(Long.parseUnsignedLong(traceId, 16))
       .spanId(Long.parseUnsignedLong(spanId, 16))
       .sampled(true).build();
 
-    assertThat(writeTraceparentFormat(context))
+    assertThat(traceparentFormat.write(context))
       .isEqualTo("00-0000000000000000" + traceId + "-" + spanId + "-01")
-      .isEqualTo(new String(writeTraceparentFormatAsBytes(context), UTF_8));
+      .isEqualTo(new String(traceparentFormat.writeAsBytes(context), UTF_8));
   }
 
   /** debug isn't the same as sampled, but we have no better choice */
-  @Test void writeTraceparentFormat_debug() {
+  @Test void write_debug() {
     TraceContext context = TraceContext.newBuilder()
       .traceId(Long.parseUnsignedLong(traceId, 16))
       .spanId(Long.parseUnsignedLong(spanId, 16))
       .debug(true).build();
 
-    assertThat(writeTraceparentFormat(context))
+    assertThat(traceparentFormat.write(context))
       .isEqualTo("00-0000000000000000" + traceId + "-" + spanId + "-01")
-      .isEqualTo(new String(writeTraceparentFormatAsBytes(context), UTF_8));
+      .isEqualTo(new String(traceparentFormat.writeAsBytes(context), UTF_8));
   }
 
   /**
    * There is no field for the parent ID in "traceparent" format. What it calls "parent ID" is
    * actually the span ID.
    */
-  @Test void writeTraceparentFormat_parent() {
+  @Test void write_parent() {
     TraceContext context = TraceContext.newBuilder()
       .traceId(Long.parseUnsignedLong(traceId, 16))
       .parentId(Long.parseUnsignedLong(parentId, 16))
       .spanId(Long.parseUnsignedLong(spanId, 16))
       .sampled(true).build();
 
-    assertThat(writeTraceparentFormat(context))
+    assertThat(traceparentFormat.write(context))
       .isEqualTo("00-0000000000000000" + traceId + "-" + spanId + "-01")
-      .isEqualTo(new String(writeTraceparentFormatAsBytes(context), UTF_8));
+      .isEqualTo(new String(traceparentFormat.writeAsBytes(context), UTF_8));
   }
 
-  @Test void writeTraceparentFormat_largest() {
+  @Test void write_largest() {
     TraceContext context = TraceContext.newBuilder()
       .traceIdHigh(Long.parseUnsignedLong(traceIdHigh, 16))
       .traceId(Long.parseUnsignedLong(traceId, 16))
@@ -108,13 +98,13 @@ class TraceparentFormatTest {
       .spanId(Long.parseUnsignedLong(spanId, 16))
       .debug(true).build();
 
-    assertThat(writeTraceparentFormat(context))
+    assertThat(traceparentFormat.write(context))
       .isEqualTo("00-" + traceIdHigh + traceId + "-" + spanId + "-01")
-      .isEqualTo(new String(writeTraceparentFormatAsBytes(context), UTF_8));
+      .isEqualTo(new String(traceparentFormat.writeAsBytes(context), UTF_8));
   }
 
-  @Test void parseTraceparentFormat_sampled() {
-    assertThat(parseTraceparentFormat("00-" + traceIdHigh + traceId + "-" + spanId + "-01"))
+  @Test void parse_sampled() {
+    assertThat(traceparentFormat.parse("00-" + traceIdHigh + traceId + "-" + spanId + "-01"))
       .usingRecursiveComparison().isEqualTo(TraceContext.newBuilder()
       .traceIdHigh(Long.parseUnsignedLong(traceIdHigh, 16))
       .traceId(Long.parseUnsignedLong(traceId, 16))
@@ -123,8 +113,8 @@ class TraceparentFormatTest {
     );
   }
 
-  @Test void parseTraceparentFormat_unsampled() {
-    assertThat(parseTraceparentFormat("00-" + traceIdHigh + traceId + "-" + spanId + "-00"))
+  @Test void parse_unsampled() {
+    assertThat(traceparentFormat.parse("00-" + traceIdHigh + traceId + "-" + spanId + "-00"))
       .usingRecursiveComparison().isEqualTo(TraceContext.newBuilder()
       .traceIdHigh(Long.parseUnsignedLong(traceIdHigh, 16))
       .traceId(Long.parseUnsignedLong(traceId, 16))
@@ -133,8 +123,9 @@ class TraceparentFormatTest {
     );
   }
 
-  @Test void parseTraceparentFormat_padded() {
-    assertThat(parseTraceparentFormat("00-0000000000000000" + traceId + "-" + spanId + "-01"))
+  @Test void parse_padded() {
+    assertThat(
+      traceparentFormat.parse("00-0000000000000000" + traceId + "-" + spanId + "-01"))
       .usingRecursiveComparison().isEqualTo(TraceContext.newBuilder()
       .traceId(Long.parseUnsignedLong(traceId, 16))
       .spanId(Long.parseUnsignedLong(spanId, 16))
@@ -142,8 +133,9 @@ class TraceparentFormatTest {
     );
   }
 
-  @Test void parseTraceparentFormat_padded_right() {
-    assertThat(parseTraceparentFormat("00-" + traceIdHigh + "0000000000000000-" + spanId + "-01"))
+  @Test void parse_padded_right() {
+    assertThat(
+      traceparentFormat.parse("00-" + traceIdHigh + "0000000000000000-" + spanId + "-01"))
       .usingRecursiveComparison().isEqualTo(TraceContext.newBuilder()
       .traceIdHigh(Long.parseUnsignedLong(traceIdHigh, 16))
       .spanId(Long.parseUnsignedLong(spanId, 16))
@@ -151,8 +143,8 @@ class TraceparentFormatTest {
     );
   }
 
-  @Test void parseTraceparentFormat_newer_version() {
-    assertThat(parseTraceparentFormat("10-" + traceIdHigh + traceId + "-" + spanId + "-00"))
+  @Test void parse_newer_version() {
+    assertThat(traceparentFormat.parse("10-" + traceIdHigh + traceId + "-" + spanId + "-00"))
       .usingRecursiveComparison().isEqualTo(TraceContext.newBuilder()
       .traceIdHigh(Long.parseUnsignedLong(traceIdHigh, 16))
       .traceId(Long.parseUnsignedLong(traceId, 16))
@@ -161,8 +153,9 @@ class TraceparentFormatTest {
     );
   }
 
-  @Test void parseTraceparentFormat_newer_version_ignores_extra_fields() {
-    assertThat(parseTraceparentFormat("10-" + traceIdHigh + traceId + "-" + spanId + "-00-fobaly"))
+  @Test void parse_newer_version_ignores_extra_fields() {
+    assertThat(
+      traceparentFormat.parse("10-" + traceIdHigh + traceId + "-" + spanId + "-00-fobaly"))
       .usingRecursiveComparison().isEqualTo(TraceContext.newBuilder()
       .traceIdHigh(Long.parseUnsignedLong(traceIdHigh, 16))
       .traceId(Long.parseUnsignedLong(traceId, 16))
@@ -171,8 +164,8 @@ class TraceparentFormatTest {
     );
   }
 
-  @Test void parseTraceparentFormat_newer_version_ignores_extra_flags() {
-    assertThat(parseTraceparentFormat("10-" + traceIdHigh + traceId + "-" + spanId + "-ff"))
+  @Test void parse_newer_version_ignores_extra_flags() {
+    assertThat(traceparentFormat.parse("10-" + traceIdHigh + traceId + "-" + spanId + "-ff"))
       .usingRecursiveComparison().isEqualTo(TraceContext.newBuilder()
       .traceIdHigh(Long.parseUnsignedLong(traceIdHigh, 16))
       .traceId(Long.parseUnsignedLong(traceId, 16))
@@ -182,9 +175,9 @@ class TraceparentFormatTest {
   }
 
   /** for example, parsing inside tracestate */
-  @Test void parseTraceparentFormat_middleOfString() {
+  @Test void parse_middleOfString() {
     String input = "tc=00-" + traceIdHigh + traceId + "-" + spanId + "-01,";
-    assertThat(parseTraceparentFormat(input, 3, input.length() - 1))
+    assertThat(traceparentFormat.parse(input, 3, input.length() - 1))
       .usingRecursiveComparison().isEqualTo(TraceContext.newBuilder()
       .traceIdHigh(Long.parseUnsignedLong(traceIdHigh, 16))
       .traceId(Long.parseUnsignedLong(traceId, 16))
@@ -193,169 +186,159 @@ class TraceparentFormatTest {
     );
   }
 
-  @Test void parseTraceparentFormat_middleOfString_incorrectIndex() {
+  @Test void parse_middleOfString_incorrectIndex() {
     String input = "tc=00-" + traceIdHigh + traceId + "-" + spanId + "-00,";
-    try (MockedStatic<Platform> mb = mockStatic(Platform.class)) {
-      mb.when(Platform::get).thenReturn(platform);
 
-      assertThat(parseTraceparentFormat(input, 0, 12))
-        .isNull(); // instead of raising exception
-    }
-
-    verify(platform)
-      .log("Invalid input: only valid characters are lower-hex for {0}", "version", null);
+    assertThatThrownBy(() -> traceparentFormat.parse(input, 0, 12))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessage("Invalid input: only valid characters are lower-hex for version");
   }
 
   /** This tests that the being index is inclusive and the end index is exclusive */
-  @Test void parseTraceparentFormat_ignoresBeforeAndAfter() {
+  @Test void parse_ignoresBeforeAndAfter() {
     String encoded = "00-" + traceIdHigh + traceId + "-" + spanId + "-01";
     String sequence = "??" + encoded + "??";
-    assertThat(parseTraceparentFormat(sequence, 2, 2 + encoded.length()))
-      .usingRecursiveComparison().isEqualTo(parseTraceparentFormat(encoded));
+    assertThat(traceparentFormat.parse(sequence, 2, 2 + encoded.length()))
+      .usingRecursiveComparison().isEqualTo(traceparentFormat.parse(encoded));
   }
 
-  @Test void parseTraceparentFormat_malformed() {
-    assertParseTraceparentFormatIsNull("not-a-tumor");
-
-    verify(platform)
-      .log("Invalid input: only valid characters are lower-hex for {0}", "version", null);
+  @Test void parse_malformed() {
+    assertThatThrownBy(() -> traceparentFormat.parse("not-a-tumor"))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessage("Invalid input: only valid characters are lower-hex for version");
   }
 
-  @Test void parseTraceparentFormat_malformed_notAscii() {
-    assertParseTraceparentFormatIsNull(
-      "00-" + traceIdHigh + traceId + "-" + spanId.substring(0, 15) + "💩-1");
-
-    verify(platform)
-      .log("Invalid input: only valid characters are lower-hex for {0}", "parent ID", null);
+  @Test void parse_malformed_notAscii() {
+    assertThatThrownBy(() -> traceparentFormat.parse(
+      "00-" + traceIdHigh + traceId + "-" + spanId.substring(0, 15) + "💩-1"))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessage("Invalid input: only valid characters are lower-hex for parent ID");
   }
 
-  @Test void parseTraceparentFormat_malformed_uuid() {
-    assertParseTraceparentFormatIsNull("b970dafd-0d95-40aa-95d8-1d8725aebe40");
-
-    verify(platform).log("Invalid input: {0} is too long", "version", null);
+  @Test void parse_malformed_uuid() {
+    assertThatThrownBy(() -> traceparentFormat.parse("b970dafd-0d95-40aa-95d8-1d8725aebe40"))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessage("Invalid input: version is too long");
   }
 
-  @Test void parseTraceparentFormat_short_traceId() {
-    assertParseTraceparentFormatIsNull("00-" + traceId + "-" + spanId + "-01");
-
-    verify(platform).log("Invalid input: {0} is too short", "trace ID", null);
+  @Test void parse_short_traceId() {
+    String parent = "00-" + traceId + "-" + spanId + "-01";
+    assertThatThrownBy(() -> traceparentFormat.parse(parent))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessage("Invalid input: trace ID is too short");
   }
 
-  @Test void parseTraceparentFormat_zero_traceId() {
-    assertParseTraceparentFormatIsNull("00-00000000000000000000000000000000-" + spanId + "-01");
-
-    verify(platform).log("Invalid input: read all zeros {0}", "trace ID", null);
+  @Test void parse_zero_traceId() {
+    String parent = "00-00000000000000000000000000000000-" + spanId + "-01";
+    assertThatThrownBy(() -> traceparentFormat.parse(parent))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessage("Invalid input: read all zeros trace ID");
   }
 
-  @Test void parseTraceparentFormat_fails_on_extra_flags() {
-    assertParseTraceparentFormatIsNull("00-" + traceIdHigh + traceId + "-" + spanId + "-ff");
-
-    verify(platform).log("Invalid input: only choices are 00 or 01 {0}", "trace flags", null);
+  @Test void parse_fails_on_extra_flags() {
+    String parent = "00-" + traceIdHigh + traceId + "-" + spanId + "-ff";
+    assertThatThrownBy(() -> traceparentFormat.parse(parent))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessage("Invalid input: only choices are 00 or 01 trace flags");
   }
 
-  @Test void parseTraceparentFormat_fails_on_extra_fields() {
-    assertParseTraceparentFormatIsNull("00-" + traceIdHigh + traceId + "-" + spanId + "-0-");
-
-    verify(platform).log("Invalid input: {0} is too short", "trace flags", null);
+  @Test void parse_fails_on_extra_fields() {
+    String parent = "00-" + traceIdHigh + traceId + "-" + spanId + "-0-";
+    assertThatThrownBy(() -> traceparentFormat.parse(parent))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessage("Invalid input: trace flags is too short");
   }
 
-  @Test void parseTraceparentFormat_fails_on_version_ff() {
-    assertParseTraceparentFormatIsNull("ff-" + traceIdHigh + traceId + "-" + spanId + "-01");
-
-    verify(platform).log("Invalid input: ff {0}", "version", null);
+  @Test void parse_fails_on_version_ff() {
+    String input = "ff-" + traceIdHigh + traceId + "-" + spanId + "-01";
+    assertThatThrownBy(() -> traceparentFormat.parse(input))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessage("Invalid input: ff version");
   }
 
-  @Test void parseTraceparentFormat_zero_spanId() {
+  @Test void parse_zero_spanId() {
     String parent = "00-" + traceIdHigh + traceId + "-0000000000000000-01";
-    assertParseTraceparentFormatIsNull(parent);
-
-    verify(platform).log("Invalid input: read all zeros {0}", "parent ID", null);
+    assertThatThrownBy(() -> traceparentFormat.parse(parent))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessage("Invalid input: read all zeros parent ID");
   }
 
-  @Test void parseTraceparentFormat_empty() {
-    assertParseTraceparentFormatIsNull("");
-
-    verify(platform).log("Invalid input: empty", null);
+  @Test void parse_empty() {
+    assertThatThrownBy(() -> traceparentFormat.parse(""))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessage("Invalid input: empty");
   }
 
-  @Test void parseTraceparentFormat_empty_version() {
-    assertParseTraceparentFormatIsNull("-" + traceIdHigh + traceId + "-" + spanId + "-00");
-
-    verify(platform).log("Invalid input: empty {0}", "version", null);
+  @Test void parse_empty_version() {
+    assertThatThrownBy(
+      () -> traceparentFormat.parse("-" + traceIdHigh + traceId + "-" + spanId + "-00"))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessage("Invalid input: empty version");
   }
 
-  @Test void parseTraceparentFormat_empty_traceId() {
-    assertParseTraceparentFormatIsNull("00--" + spanId + "-00");
-
-    verify(platform).log("Invalid input: empty {0}", "trace ID", null);
+  @Test void parse_empty_traceId() {
+    assertThatThrownBy(() -> traceparentFormat.parse("00--" + spanId + "-00"))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessage("Invalid input: empty trace ID");
   }
 
-  @Test void parseTraceparentFormat_empty_spanId() {
-    assertParseTraceparentFormatIsNull("00-" + traceIdHigh + traceId + "--01");
-
-    verify(platform).log("Invalid input: empty {0}", "parent ID", null);
+  @Test void parse_empty_spanId() {
+    assertThatThrownBy(() -> traceparentFormat.parse("00-" + traceIdHigh + traceId + "--01"))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessage("Invalid input: empty parent ID");
   }
 
-  @Test void parseTraceparentFormat_empty_flags() {
-    assertParseTraceparentFormatIsNull("00-" + traceIdHigh + traceId + "-" + spanId + "-");
-
-    verify(platform).log("Invalid input: empty {0}", "trace flags", null);
+  @Test void parse_empty_flags() {
+    assertThatThrownBy(
+      () -> traceparentFormat.parse("00-" + traceIdHigh + traceId + "-" + spanId + "-"))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessage("Invalid input: empty trace flags");
   }
 
-  @Test void parseTraceparentFormat_truncated_traceId() {
-    assertParseTraceparentFormatIsNull("00-1-" + spanId + "-01");
-
-    verify(platform).log("Invalid input: {0} is too short", "trace ID", null);
+  @Test void parse_truncated_traceId() {
+    assertThatThrownBy(() -> traceparentFormat.parse("00-1-" + spanId + "-01"))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessage("Invalid input: trace ID is too short");
   }
 
-  @Test void parseTraceparentFormat_truncated_traceId128() {
-    assertParseTraceparentFormatIsNull("00-1" + traceId + "-" + spanId + "-01");
-
-    verify(platform).log("Invalid input: {0} is too short", "trace ID", null);
+  @Test void parse_truncated_traceId128() {
+    assertThatThrownBy(() -> traceparentFormat.parse("00-1" + traceId + "-" + spanId + "-01"))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessage("Invalid input: trace ID is too short");
   }
 
-  @Test void parseTraceparentFormat_truncated_spanId() {
-    assertParseTraceparentFormatIsNull(
-      "00-" + traceIdHigh + traceId + "-" + spanId.substring(0, 15) + "-00");
-
-    verify(platform).log("Invalid input: {0} is too short", "parent ID", null);
+  @Test void parse_truncated_spanId() {
+    assertThatThrownBy(() -> traceparentFormat.parse(
+      "00-" + traceIdHigh + traceId + "-" + spanId.substring(0, 15) + "-00"))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessage("Invalid input: parent ID is too short");
   }
 
-  @Test void parseTraceparentFormat_truncated_flags() {
-    assertParseTraceparentFormatIsNull("00-" + traceIdHigh + traceId + "-" + spanId + "-0");
-
-    verify(platform).log("Invalid input: {0} is too short", "trace flags", null);
+  @Test void parse_truncated_flags() {
+    String input = "00-" + traceIdHigh + traceId + "-" + spanId + "-0";
+    assertThatThrownBy(() -> traceparentFormat.parse(input))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessage("Invalid input: trace flags is too short", "trace flags");
   }
 
-  @Test void parseTraceparentFormat_traceIdTooLong() {
-    assertParseTraceparentFormatIsNull(
-      "00-" + traceIdHigh + traceId + "a" + "-" + spanId + "-0");
-
-    verify(platform).log("Invalid input: {0} is too long", "trace ID", null);
+  @Test void parse_traceIdTooLong() {
+    String input = "00-" + traceIdHigh + traceId + "a" + "-" + spanId + "-0";
+    assertThatThrownBy(() -> traceparentFormat.parse(input))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessage("Invalid input: trace ID is too long");
   }
 
-  @Test void parseTraceparentFormat_spanIdTooLong() {
-    assertParseTraceparentFormatIsNull("00-" + traceIdHigh + traceId + "-" + spanId + "a-0");
-
-    verify(platform).log("Invalid input: {0} is too long", "parent ID", null);
+  @Test void parse_spanIdTooLong() {
+    String input = "00-" + traceIdHigh + traceId + "-" + spanId + "a-0";
+    assertThatThrownBy(() -> traceparentFormat.parse(input))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessage("Invalid input: parent ID is too long");
   }
 
-  @Test void parseTraceparentFormat_flagsTooLong() {
-    assertParseTraceparentFormatIsNull("00-" + traceIdHigh + traceId + "-" + spanId + "-001");
-
-    verify(platform).log("Invalid input: too long", null);
-  }
-
-  /**
-   * This calls {@link TraceparentFormat#parseTraceparentFormat(CharSequence)}, after setting {@link
-   * Platform#get()} to return {@link #platform} for log assertions.
-   */
-  void assertParseTraceparentFormatIsNull(String encoded) {
-    try (MockedStatic<Platform> mb = mockStatic(Platform.class)) {
-      mb.when(Platform::get).thenReturn(platform);
-
-      assertThat(TraceparentFormat.parseTraceparentFormat(encoded))
-        .isNull(); // instead of raising exception
-    }
+  @Test void parse_flagsTooLong() {
+    String input = "00-" + traceIdHigh + traceId + "-" + spanId + "-001";
+    assertThatThrownBy(() -> traceparentFormat.parse(input))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessage("Invalid input: too long");
   }
 }

--- a/tracecontext/src/test/java/brave/propagation/tracecontext/TracestateFormatTest.java
+++ b/tracecontext/src/test/java/brave/propagation/tracecontext/TracestateFormatTest.java
@@ -34,7 +34,7 @@ class TracestateFormatTest {
   static final String LONGEST_TENANT_KEY =
     "1" + TWO_HUNDRED_FORTY_KEY_CHARS + "@" + FORTY_KEY_CHARS.substring(0, 13);
 
-  TracestateFormat tracestateFormat = new TracestateFormat(true);
+  TracestateFormat tracestateFormat = new TracestateFormat("b3", true);
 
   // all these need log assertions
   @Test void validateKey_empty() {


### PR DESCRIPTION
This reworks TraceContextExtractor using utilities recently added to brave:
https://github.com/openzipkin/brave/pull/1284

The main idea is that this allows us to split tracestate without allocating
any strings. The current implementation remains incomplete, but this phase
sets the stage for completion.