### PR TITLE
Exposes symbols for extracting traceparent in micrometer tracing

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,15 +16,6 @@ jobs:
   deploy:
     name: deploy (${{ matrix.name }})
     runs-on: ubuntu-22.04  # newest available distribution, aka jellyfish
-    strategy:
-      fail-fast: false  # don't fail fast as we can re-run one job that failed
-      matrix:
-        include:
-          - name: jars
-            deploy_script: build-bin/deploy
-          # Deploy the Bill of Materials (BOM) separately as it is unhooked from the main project intentionally
-          - name: bom
-            deploy_script: build-bin/deploy_bom
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -61,4 +52,4 @@ jobs:
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
         run: |  # GITHUB_REF will be refs/heads/master or refs/tags/MAJOR.MINOR.PATCH
           build-bin/configure_deploy &&
-          ${{ matrix.deploy_script }} $(echo ${GITHUB_REF} | cut -d/ -f 3)
+          build-bin/deploy $(echo ${GITHUB_REF} | cut -d/ -f 3)

--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
     <maven-release-plugin.version>3.0.1</maven-release-plugin.version>
     <maven-shade-plugin.version>3.5.1</maven-shade-plugin.version>
     <maven-source-plugin.version>3.3.0</maven-source-plugin.version>
-    <maven-surefire-plugin.version>3.2.3</maven-surefire-plugin.version>
+    <maven-surefire-plugin.version>3.2.5</maven-surefire-plugin.version>
     <nexus-staging-maven-plugin.version>1.6.13</nexus-staging-maven-plugin.version>
   </properties>
 

--- a/tracecontext/src/main/java/brave/propagation/tracecontext/TraceContextPropagation.java
+++ b/tracecontext/src/main/java/brave/propagation/tracecontext/TraceContextPropagation.java
@@ -26,7 +26,7 @@ import java.util.logging.Logger;
 import static java.util.Arrays.asList;
 
 public final class TraceContextPropagation implements Propagation<String> {
-  static final String TRACEPARENT = "traceparent", TRACESTATE = "tracestate";
+  public static final String TRACEPARENT = "traceparent", TRACESTATE = "tracestate";
   public static final Propagation.Factory FACTORY = new Factory(newFactoryBuilder());
   static final Propagation<String> INSTANCE = FACTORY.get();
 

--- a/tracecontext/src/main/java/brave/propagation/tracecontext/TraceparentFormat.java
+++ b/tracecontext/src/main/java/brave/propagation/tracecontext/TraceparentFormat.java
@@ -20,12 +20,10 @@ import java.nio.ByteBuffer;
 import static brave.internal.codec.HexCodec.writeHexLong;
 
 /** Implements <a href="https://tracecontext.github.io/trace-context/#traceparent-header">...</a> */
-// TODO: this uses the internal Platform class as it defers access to the logger and makes JUL less
-// expensive. We should inline that here to to unhook the internal dep.
-final class TraceparentFormat {
+public final class TraceparentFormat {
   static final TraceparentFormat INSTANCE = new TraceparentFormat(false);
 
-  static TraceparentFormat get() {
+  public static TraceparentFormat get() {
     return INSTANCE;
   }
 
@@ -44,7 +42,7 @@ final class TraceparentFormat {
   }
 
   /** Writes all "traceparent" defined fields in the trace context to a hyphen delimited string. */
-  String write(TraceContext context) {
+  public String write(TraceContext context) {
     char[] buffer = getCharBuffer();
     int length = write(context, buffer);
     return new String(buffer, 0, length);
@@ -54,7 +52,7 @@ final class TraceparentFormat {
    * Like {@link #write(TraceContext)}, but for requests with byte array or byte buffer values. For
    * example, {@link ByteBuffer#wrap(byte[])} can wrap the result.
    */
-  byte[] writeAsBytes(TraceContext context) {
+  public byte[] writeAsBytes(TraceContext context) {
     char[] buffer = getCharBuffer();
     int length = write(context, buffer);
     return asciiToNewByteArray(buffer, length);
@@ -81,7 +79,7 @@ final class TraceparentFormat {
     return pos;
   }
 
-  @Nullable TraceContext parse(CharSequence parent) {
+  @Nullable public TraceContext parse(CharSequence parent) {
     return parse(parent, 0, parent.length(), shouldThrow);
   }
 
@@ -95,7 +93,7 @@ final class TraceparentFormat {
    * @param endIndex   the exclusive end index: {@linkplain CharSequence#charAt(int) index}
    *                   <em>after</em> the last character in {@code traceparent} format.
    */
-  @Nullable TraceContext parse(CharSequence value, int beginIndex, int endIndex) {
+  @Nullable public TraceContext parse(CharSequence value, int beginIndex, int endIndex) {
     return parse(value, beginIndex, endIndex, shouldThrow);
   }
 


### PR DESCRIPTION
This starts integration testing by exposing traceparent code. The tracestate code, I'm not exposing yet, as the impl here carries the b3 context, needed to properly propagate debug, never sample and shared bits. Regardless, the traceparent code is helpful to other libs.